### PR TITLE
feat: send email when creating a snippet using Celery

### DIFF
--- a/snippets/tasks.py
+++ b/snippets/tasks.py
@@ -1,19 +1,11 @@
 from django.core.mail import send_mail
 
 from django_snippets.settings import EMAIL_HOST_USER as sender
+from celery import shared_task
 
-# Send an email notification to the user when a snippet is created.
-# The email contains the snippet's name and description.
-# TODO: Implement email sending logic and integrate with Celery
+@shared_task
 def sendEmailInSnippetCreation(snippet_name, snippet_description, user_mail):
-    # subject = 'Snippet "' + snippet_name + '" created successfully'
-    # body = (
-    #     'The snippet "' + snippet_name + '" was created with the following description: \n'
-    #     + snippet_description
-    # )
-
-    # Only send the email if the user has registered an email address
     if user_mail:
-        # TODO: Fill in the email sending logic
-        # Placeholder: send_mail(subject, body, sender, [])
-        pass
+        subject = 'Snippet "' + snippet_name + '" created successfully'
+        body = f'The snippet "{snippet_name}" was created with the following description: \n{snippet_description}'
+        send_mail(subject, body, sender, [user_mail])

--- a/snippets/views.py
+++ b/snippets/views.py
@@ -10,6 +10,7 @@ from pygments.formatters import HtmlFormatter
 from pygments import highlight
 from .models import Snippet, Language
 from .forms import SnippetForm
+from .tasks import sendEmailInSnippetCreation
 
 class SnippetAdd(LoginRequiredMixin, View):
     template_name = "snippets/snippet_add.html"
@@ -25,6 +26,7 @@ class SnippetAdd(LoginRequiredMixin, View):
             snippet = form.save(commit=False)
             snippet.user = request.user
             snippet.save()
+            sendEmailInSnippetCreation.delay(snippet.name, snippet.description, request.user.email)
             return redirect("snippet", id=snippet.id)
         return render(request, self.template_name, {"form": form, "action": "Add"})
 


### PR DESCRIPTION
✨ Feature:

Added an feature to send an email when a new snippet is created.
The email subject contains the snippet's name, and the body includes its description.
The email is sent asynchronously using Celery to improve scalability.

🔧 Changes made:

Created a Celery task to handle email sending.
Updated the snippet creation view to trigger the Celery task.
Configured Django's email backend to support email sending.

📌 Additional notes:

The email notification and only occurs during snippet creation, not on updates.
Celery and a broker (e.g., Redis) must be running for asynchronous execution.